### PR TITLE
Fix global variables for GCC 10

### DIFF
--- a/chavrprog.c
+++ b/chavrprog.c
@@ -59,6 +59,15 @@ unsigned char read_fs[3][4]={{0b01010000, 0b00000000,  0x00, 0x00},
 
 unsigned char fuses[3];
 
+unsigned char * data_buffer;
+unsigned char spi_data[4];
+unsigned char device_sign[3];
+int cfg_pagesize;
+int cfg_num_of_pages;
+int cfg_eeprom;
+unsigned cfg_pageshift;
+unsigned cfg_pagemask;
+int cfg_pagemsq;
 
 void debug_call(void){
     printf("Using delay of %d us\n", delay);

--- a/chavrprog.h
+++ b/chavrprog.h
@@ -30,15 +30,15 @@
 
 
 
-unsigned char * data_buffer;
-unsigned char spi_data[4];
-unsigned char device_sign[3];
-int cfg_pagesize;
-int cfg_num_of_pages;
-int cfg_eeprom;
-unsigned cfg_pageshift;
-unsigned cfg_pagemask;
-int cfg_pagemsq;
+extern unsigned char * data_buffer;
+extern unsigned char spi_data[4];
+extern unsigned char device_sign[3];
+extern int cfg_pagesize;
+extern int cfg_num_of_pages;
+extern int cfg_eeprom;
+extern unsigned cfg_pageshift;
+extern unsigned cfg_pagemask;
+extern int cfg_pagemsq;
 
 void debug_call(void);
 void toggle_reset(short stat);

--- a/config.h
+++ b/config.h
@@ -30,6 +30,6 @@ typedef struct{
   const int cfg_eeprom;
 } devconf_t;
 
-const devconf_t confset[CONF_LENGTH];
+extern const devconf_t confset[CONF_LENGTH];
 
 #endif


### PR DESCRIPTION
Hey there! I was getting build errors like:
```
/usr/bin/ld: /tmp/ccLarY3u.o:(.rodata+0x0): multiple definition of `confset'; /tmp/ccC14b8u.o:(.rodata+0x0): first defined here
/usr/bin/ld: /tmp/ccLarY3u.o:(.bss+0x0): multiple definition of `data_buffer'; /tmp/ccC14b8u.o:(.bss+0x0): first defined here
/usr/bin/ld: /tmp/ccLarY3u.o:(.bss+0x8): multiple definition of `spi_data'; /tmp/ccC14b8u.o:(.bss+0x8): first defined here
/usr/bin/ld: /tmp/ccLarY3u.o:(.bss+0xc): multiple definition of `device_sign'; /tmp/ccC14b8u.o:(.bss+0xc): first defined here
/usr/bin/ld: /tmp/ccLarY3u.o:(.bss+0x10): multiple definition of `cfg_pagesize'; /tmp/ccC14b8u.o:(.bss+0x10): first defined here
/usr/bin/ld: /tmp/ccLarY3u.o:(.bss+0x14): multiple definition of `cfg_num_of_pages'; /tmp/ccC14b8u.o:(.bss+0x14): first defined here
/usr/bin/ld: /tmp/ccLarY3u.o:(.bss+0x18): multiple definition of `cfg_eeprom'; /tmp/ccC14b8u.o:(.bss+0x18): first defined here
/usr/bin/ld: /tmp/ccLarY3u.o:(.bss+0x1c): multiple definition of `cfg_pageshift'; /tmp/ccC14b8u.o:(.bss+0x1c): first defined here
/usr/bin/ld: /tmp/ccLarY3u.o:(.bss+0x20): multiple definition of `cfg_pagemask'; /tmp/ccC14b8u.o:(.bss+0x20): first defined here
/usr/bin/ld: /tmp/ccLarY3u.o:(.bss+0x24): multiple definition of `cfg_pagemsq'; /tmp/ccC14b8u.o:(.bss+0x24): first defined here
/usr/bin/ld: /tmp/cc8LMP1v.o:(.data.rel.ro.local+0x0): multiple definition of `confset'; /tmp/ccC14b8u.o:(.rodata+0x0): first defined here
collect2: error: ld returned 1 exit status
```

It looks like GCC10 [changed some defaults](https://gcc.gnu.org/gcc-10/porting_to.html), so I added `extern`s to the global variables. 